### PR TITLE
Update choosing-core-framework-server.md

### DIFF
--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -62,7 +62,7 @@ ms.lasthandoff: 03/15/2017
 
 當您的系統需要最佳效能和延展性時，.NET Core 和 ASP.NET Core 就是最好的選擇。 ASP.NET Core 的功能勝過 ASP.NET 10 倍，並且在像 Java servlets、Go 和 node.js 等微服務領域中領先其他熱門的業界技術。
 
-這對於微服務架構特別重要，您可以在其中執行數百個微服務。 透過 ASP.NET Core，您就能使用較低數目的服務/VM 來執行系統，最終能省下基礎結構與裝載的相關成本。
+這對於微服務架構特別重要，您可以在其中執行數百個微服務。 透過 ASP.NET Core，您就能使用較低數目的伺服器/VM 來執行系統，最終能省下基礎結構與裝載的相關成本。
 
 ### <a name="a-need-for-side-by-side-of-net-versions-per-application-level"></a>需要針對每個應用程式層級並存各個 .NET 版本
 
@@ -78,7 +78,7 @@ ms.lasthandoff: 03/15/2017
 
 ### <a name="a-need-to-use-third-party-net-libraries-or-nuget-packages-not-available-for-net-core"></a>需要使用的協力廠商的 .NET 程式庫或 NuGet 套件不適用 .NET Core
 
-程式庫會快速採行 .NET 標準，以便跨所有 .NET 類別 (包括 .NET Core) 共用程式碼。 透過 .NET 標準 2.0，這甚至更加簡單，因為 .NET Core API 介面將明顯變大，而 .NET Core 應用程式可以直接使用現有的 .NET Framework 程式庫。 但此轉換不是即時的，因此我們建議您先檢查應用程式所需的特定程式庫，然後再以其他方式進行決策。
+程式庫會快速採行 .NET Standard，以便跨所有 .NET 類別 (包括 .NET Core) 共用程式碼。 透過 .NET Standard 2.0，這甚至更加簡單，因為 .NET Core API 介面將明顯變大，而 .NET Core 應用程式可以直接使用現有的 .NET Framework 程式庫。 但此轉換不是即時的，因此我們建議您先檢查應用程式所需的特定程式庫，然後再以其他方式進行決策。
 
 ### <a name="a-need-to-use-net-technologies-not-available-for-net-core"></a>需要使用的 .NET 技術不適用 .NET Core
 
@@ -102,7 +102,7 @@ ms.lasthandoff: 03/15/2017
 
 ### <a name="a-need-to-use-a-platform-that-doesnt-support-net-core"></a>必須使用不支援 .NET Core 的平台
 
-某些 Microsoft 或協力廠商平台不支援 .NET Core。 例如，某些 Azure 服務 (例如 Service Fabric 具狀態可靠服務和 Service Fabric Reliable Actors) 需要 .NET Framework。 部分其他服務提供尚無法在 .NET Core 上使用的 SDK。 這是過渡期，因為所有的 Azure 服務都會使用 .NET Core。 在此同時，您永遠都能使用對等的 REST API，而非用戶端 SDK。
+某些 Microsoft 或協力廠商平台不支援 .NET Core。 例如，某些 Azure 服務 (例如 Service Fabric Stateful Reliable Services 和 Service Fabric Reliable Actors) 需要 .NET Framework。 部分其他服務提供尚無法在 .NET Core 上使用的 SDK。 這是過渡期，因為所有的 Azure 服務都會使用 .NET Core。 在此同時，您永遠都能使用對等的 REST API，而非用戶端 SDK。
 
 ## <a name="further-resources"></a>其他資源
 


### PR DESCRIPTION
1. 原文是 servers/VMs 應翻成「伺服器/VM 」不是「服務/VM」
2. 和 .NET Core / .NET Framework 一樣，.NET Standard 不建議翻譯為「.NET 標準」
3. 「such as Service Fabric Stateful Reliable Services and Service Fabric Reliable Actors」一個有翻譯一個無翻譯，看起來很怪。保持一致比較好。