### PR TITLE
Update deploy-with-cli Article

### DIFF
--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -34,11 +34,11 @@ ms.locfileid: "43855018"
 
 1. 建立專案。
 
-   從命令列鍵入 [dotnet new console](../tools/dotnet-new.md)，以在該目錄中建立新的 C# 主控台專案。
+   從命令列鍵入 [dotnet new console](../tools/dotnet-new.md)，以在該目錄中建立新的 C# 主控台專案；或輸入 [dotnet new console -lang vb](../tools/dotnet-new.md)，已在該目錄建立新的 Visual Basic 主控台專案。
 
 1. 新增應用程式的原始程式碼。
 
-   在您的編輯器中開啟 *Program.cs* 檔案，並以下列程式碼取代自動產生的程式碼。 它會提示使用者輸入文字，並顯示使用者輸入的個別文字。 它會使用規則運算式 `\w+` 分隔輸入文字中的字詞。
+   在您的編輯器中開啟 *Program.cs* 或 *Program.vb* 檔案，並以下列程式碼取代自動產生的程式碼。 它會提示使用者輸入文字，並顯示使用者輸入的個別文字。 它會使用規則運算式 `\w+` 分隔輸入文字中的字詞。
 
    [!code-csharp[deployment#1](../../../samples/snippets/core/deploying/deployment-example.cs)]
 
@@ -55,11 +55,11 @@ ms.locfileid: "43855018"
    在您偵錯並測試程式之後，請使用下列命令來建立部署：
 
       ```console
-      dotnet publish -f netcoreapp1.1 -c Release
+      dotnet publish -f netcoreapp2.1 -c Release
       ```
    這會建立應用程式的發行 (而非偵錯) 版本。 產生的檔案會放在名為 *publish* 的目錄中，而該目錄位於您專案之 *bin* 目錄的子目錄中。
 
-   隨著應用程式檔案一起，發佈程序會發出程式資料庫 (.pdb) 檔案，其中包含應用程式的偵錯資訊。 該檔案主要是用於例外狀況偵錯。 您可以選擇不與您的應用程式檔案一起散發它。 不過，如果您要對應用程式的發行組建進行偵錯，則應該將其儲存。
+   隨著應用程式檔案一起，發佈程序會發出程式資料庫 (.pdb) 檔案，其中包含應用程式的偵錯資訊。 該檔案主要是用於例外狀況偵錯。 您可以選擇不與您的應用程式檔案一起將它發散。 不過，如果您要對應用程式的發行組建進行偵錯，則應該將其保存。
 
    您可以使用任何您想要的方式，部署整組應用程式檔案。 例如，您可以使用簡單的 `copy` 命令將它們封裝在 ZIP 檔案中，或與您選擇的任何安裝套件一起部署。
 
@@ -67,7 +67,7 @@ ms.locfileid: "43855018"
 
    安裝之後，使用者可以使用 `dotnet` 命令並提供應用程式的檔名 (例如，`dotnet fdd.dll`)，來執行您的應用程式。
 
-   除了應用程式二進位檔之外，安裝程式也應該配套共用的 Framework 安裝程式，，或勾選為必要條件當成應用程式安裝的一部分。  共用的 Framwork 安裝需要系統管理員/根目錄存取權。
+   除了應用程式二進位檔之外，安裝程式也應該配套共用的 Framework 安裝程式，或勾選為必要條件當成應用程式安裝的一部分。  共用的 Framework 安裝需要系統管理員/根目錄存取權。
 
 ## <a name="framework-dependent-deployment-with-third-party-dependencies"></a>有協力廠商相依性的 Framework 相依部署
 
@@ -105,7 +105,7 @@ ms.locfileid: "43855018"
 
 1. 定義您應用程式目標的平台。
 
-   在定義應用程式目標平台之 *csproj* 檔案的 `<PropertyGroup>` 區段中建立 `<RuntimeIdentifiers>` 標記，並指定每個目標平台的執行階段識別碼 (RID)。 請注意，您也必須加上分號來分隔 RID。 如需執行階段識別碼清單，請參閱 [Runtime IDentifier catalog](../rid-catalog.md)。
+   在定義應用程式目標平台之 *csproj* 檔案的 `<PropertyGroup>` 區段中建立 `<RuntimeIdentifiers>` 標記，並指定每個目標平台的執行階段識別碼 (RID)。 請注意，您也必須加上分號來分隔 RID。 如需執行階段識別碼清單，請參閱 [.NET Core RID 類別目錄](../rid-catalog.md)。
 
    例如，下列 `<PropertyGroup>` 區段指出應用程式在 64 位元 Windows 10 作業系統和 64 位元 OS X 版本 10.11 作業系統上執行。
 
@@ -121,6 +121,14 @@ ms.locfileid: "43855018"
 
    執行 [dotnet restore](../tools/dotnet-restore.md) ([請參閱注意事項](#dotnet-restore-note)) 命令以還原專案中指定的相依性。
 
+1. 決定您是否想要使用全球化不區分模式。
+
+   如果您的應用程式是為 Linux 所編譯，您可以透過[全球化不區分模式](https://github.com/dotnet/corefx/blob/master/Documentation/architecture/globalization-invariant-mode.md)將您自封性部屬的應用程式大小縮小。全球化不區分模式對於不能全局識別以及可使用[與文化性不相關](xref:System.Globalization.CultureInfo.InvariantCulture)的格式、大小寫區分、字串比較以及大小排列的應用程式相當有用。
+
+   若要啟用不區分模式，於**方案總管**中在您的專案(而非方案)上按下右鍵，並選擇**編輯 SCD.csproj**或**編輯SCD.vbproj**。並將下列反白顯示的字串加入至檔案中：
+  
+   [!code-xml[globalization-invariant-mode](~/samples/snippets/core/deploying/xml/invariant.csproj)]
+
 1. 建立應用程式的偵錯組建。
 
    從命令列中，使用 [dotnet build](../tools/dotnet-build.md) 命令。
@@ -134,7 +142,7 @@ ms.locfileid: "43855018"
       dotnet publish -c Release -r osx.10.11-x64
       ```
 
-   這會建立每個目標平台的應用程式發行 (而非偵錯) 版本。 產生的檔案會放在名為 *publish* 的子目錄中，而該目錄位於您專案之 *.\bin\Release\netcoreapp1.1\<執行階段識別碼>* 子目錄的子目錄中。 請注意，每個子目錄都包含啟動應用程式所需的一組完整檔案 (應用程式檔案和所有的 .NET Core 檔案)。
+   這會建立每個目標平台的應用程式發行 (而非偵錯) 版本。 產生的檔案會放在名為 *publish* 的子目錄中，而該目錄位於您專案之 *.\bin\Release\netcoreapp2.1\\<執行階段識別碼>* 子目錄的子目錄中。 請注意，每個子目錄都包含啟動應用程式所需的一組完整檔案 (應用程式檔案和所有的 .NET Core 檔案)。
 
 隨著應用程式檔案一起，發佈程序會發出程式資料庫 (.pdb) 檔案，其中包含應用程式的偵錯資訊。 該檔案主要是用於例外狀況偵錯。 您可以選擇不與您的應用程式檔案一起封裝它。 不過，如果您要對應用程式的發行組建進行偵錯，則應該將其儲存。
 
@@ -146,7 +154,7 @@ ms.locfileid: "43855018"
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>
@@ -172,7 +180,7 @@ ms.locfileid: "43855018"
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>

--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -34,11 +34,11 @@ ms.locfileid: "43855018"
 
 1. 建立專案。
 
-   從命令列鍵入 [dotnet new console](../tools/dotnet-new.md)，以在該目錄中建立新的 C# 主控台專案；或輸入 [dotnet new console -lang vb](../tools/dotnet-new.md)，已在該目錄建立新的 Visual Basic 主控台專案。
+   從命令列鍵入 [dotnet new console](../tools/dotnet-new.md)，以在該目錄中建立新的 C# 主控台專案。
 
 1. 新增應用程式的原始程式碼。
 
-   在您的編輯器中開啟 *Program.cs* 或 *Program.vb* 檔案，並以下列程式碼取代自動產生的程式碼。 它會提示使用者輸入文字，並顯示使用者輸入的個別文字。 它會使用規則運算式 `\w+` 分隔輸入文字中的字詞。
+   在您的編輯器中開啟 *Program.cs* 檔案，並以下列程式碼取代自動產生的程式碼。 它會提示使用者輸入文字，並顯示使用者輸入的個別文字。 它會使用規則運算式 `\w+` 分隔輸入文字中的字詞。
 
    [!code-csharp[deployment#1](../../../samples/snippets/core/deploying/deployment-example.cs)]
 
@@ -59,7 +59,7 @@ ms.locfileid: "43855018"
       ```
    這會建立應用程式的發行 (而非偵錯) 版本。 產生的檔案會放在名為 *publish* 的目錄中，而該目錄位於您專案之 *bin* 目錄的子目錄中。
 
-   隨著應用程式檔案一起，發佈程序會發出程式資料庫 (.pdb) 檔案，其中包含應用程式的偵錯資訊。 該檔案主要是用於例外狀況偵錯。 您可以選擇不與您的應用程式檔案一起將它發散。 不過，如果您要對應用程式的發行組建進行偵錯，則應該將其保存。
+   隨著應用程式檔案一起，發佈程序會發出程式資料庫 (.pdb) 檔案，其中包含應用程式的偵錯資訊。 該檔案主要是用於例外狀況偵錯。 您可以選擇不與您的應用程式檔案一起散發它。 不過，如果您要對應用程式的發行組建進行偵錯，則應該將其儲存。
 
    您可以使用任何您想要的方式，部署整組應用程式檔案。 例如，您可以使用簡單的 `copy` 命令將它們封裝在 ZIP 檔案中，或與您選擇的任何安裝套件一起部署。
 
@@ -105,7 +105,7 @@ ms.locfileid: "43855018"
 
 1. 定義您應用程式目標的平台。
 
-   在定義應用程式目標平台之 *csproj* 檔案的 `<PropertyGroup>` 區段中建立 `<RuntimeIdentifiers>` 標記，並指定每個目標平台的執行階段識別碼 (RID)。 請注意，您也必須加上分號來分隔 RID。 如需執行階段識別碼清單，請參閱 [.NET Core RID 類別目錄](../rid-catalog.md)。
+   在定義應用程式目標平台之 *csproj* 檔案的 `<PropertyGroup>` 區段中建立 `<RuntimeIdentifiers>` 標記，並指定每個目標平台的執行階段識別碼 (RID)。 請注意，您也必須加上分號來分隔 RID。 如需執行階段識別碼清單，請參閱 [Runtime IDentifier catalog](../rid-catalog.md)。
 
    例如，下列 `<PropertyGroup>` 區段指出應用程式在 64 位元 Windows 10 作業系統和 64 位元 OS X 版本 10.11 作業系統上執行。
 
@@ -120,14 +120,6 @@ ms.locfileid: "43855018"
 1. 更新專案的相依性和工具。
 
    執行 [dotnet restore](../tools/dotnet-restore.md) ([請參閱注意事項](#dotnet-restore-note)) 命令以還原專案中指定的相依性。
-
-1. 決定您是否想要使用全球化不區分模式。
-
-   如果您的應用程式是為 Linux 所編譯，您可以透過[全球化不區分模式](https://github.com/dotnet/corefx/blob/master/Documentation/architecture/globalization-invariant-mode.md)將您自封性部屬的應用程式大小縮小。全球化不區分模式對於不能全局識別以及可使用[與文化性不相關](xref:System.Globalization.CultureInfo.InvariantCulture)的格式、大小寫區分、字串比較以及大小排列的應用程式相當有用。
-
-   若要啟用不區分模式，於**方案總管**中在您的專案(而非方案)上按下右鍵，並選擇**編輯 SCD.csproj**或**編輯SCD.vbproj**。並將下列反白顯示的字串加入至檔案中：
-  
-   [!code-xml[globalization-invariant-mode](~/samples/snippets/core/deploying/xml/invariant.csproj)]
 
 1. 建立應用程式的偵錯組建。
 

--- a/includes/dotnet-restore-note.md
+++ b/includes/dotnet-restore-note.md
@@ -1,3 +1,3 @@
 > [!NOTE]
 > 從 .NET Core 2.0 開始，您不需要執行 [`dotnet restore`](~/docs/core/tools/dotnet-restore.md)，因為它是以隱含方式由需要進行還原的所有命令執行，例如 `dotnet new`、`dotnet build` 和 `dotnet run`。
-> 它在執行明確還原有意義的某些情況下仍然是有效的命令，例如 [Visual Studio Team Services 中的持續整合組建](https://docs.microsoft.com/vsts/build-release/apps/aspnet/build-aspnet-core)，或在需要明確控制還原進行時間的建置系統中。
+> 它在執行明確還原有意義的某些情況下仍然是有效的命令，例如 [Azure DevOps Services 中的持續整合組建](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core)，或在需要明確控制還原進行時間的建置系統中。


### PR DESCRIPTION
# Summary

This PR updates the CLI Deployment article to the latest one over at the [original](https://docs.microsoft.com/en-us/dotnet/core/deploying/deploy-with-cli), as well as fixing minor hiccups found in the translated article.