### PR TITLE
Fix two URLs that are exchange from each other

### DIFF
--- a/docs/csharp/language-reference/operators/comparison-operators.md
+++ b/docs/csharp/language-reference/operators/comparison-operators.md
@@ -69,7 +69,7 @@ ms.locfileid: "78239416"
 
 ## <a name="c-language-specification"></a>C# 語言規格
 
-如需詳細資訊，請參閱 [C# 語言規格](~/_csharplang/spec/expressions.md#relational-and-type-testing-operators)的[關係及類型測試運算子](~/_csharplang/spec/introduction.md)一節。
+如需詳細資訊，請參閱 [C# 語言規格](~/_csharplang/spec/introduction.md)的[關係及類型測試運算子](~/_csharplang/spec/expressions.md#relational-and-type-testing-operators)一節。
 
 ## <a name="see-also"></a>另請參閱
 


### PR DESCRIPTION
English:
There are two wrong URLs that exchange from each other. I fixed it by exchange them back.
Chinese:
修正了兩個彼此顛倒的連結。

一些有助於提出建議的實用資訊：
1.請參閱 Microsoft Style Guide (Microsoft 樣式指南) 之 [Quick Start Localization Style Guides](本地化樣式入門指南)(https://docs.microsoft.com/globalization/localization/styleguides) 中的 **top 10 most important rules** (10 大重要規則)。
2.前往 [Microsoft 語言入口網站](https://www.microsoft.com/zh-tw/language)，查看不同 Microsoft 產品的 **標準化詞彙翻譯**。
