### PR TITLE
繁體中文翻譯修正

### DIFF
--- a/docs/framework/get-started/system-requirements.md
+++ b/docs/framework/get-started/system-requirements.md
@@ -28,7 +28,7 @@ ms.locfileid: "81389479"
 
 如需有關 .NET Framework 4.5 之前之 .NET Framework 版本的資訊，請參閱 [.NET Framework 版本和相依性](../migration-guide/versions-and-dependencies.md)。
 
-使您能夠為 .NET Framework 開發應用的開發環境具有一組單獨的要求。
+每一個讓您用來開發 .NET Framework 應用程式的開發環境，都有不同的需求項目。
 
 [!INCLUDE[net-framework-4-versions](../../../includes/net-framework-4x-versions.md)]
 


### PR DESCRIPTION
此句子「使您能夠為 .NET Framework 開發應用的開發環境具有一組單獨的要求。」之原文為下列所述：
Development environments that enable you to develop apps for .NET Framework have a separate set of requirements.

應翻譯為「每一個讓您用來開發 .NET Framework 應用程式的開發環境，都有不同的需求項目。」

一些有助於提出建議的實用資訊：
1.請參閱 Microsoft Style Guide (Microsoft 樣式指南) 之 [Quick Start Localization Style Guides](本地化樣式入門指南)(https://docs.microsoft.com/globalization/localization/styleguides) 中的 **top 10 most important rules** (10 大重要規則)。
2.前往 [Microsoft 語言入口網站](https://www.microsoft.com/zh-tw/language)，查看不同 Microsoft 產品的 **標準化詞彙翻譯**。
